### PR TITLE
include prefix-declared data attributes in getAllWorkflowDataAttributes

### DIFF
--- a/IWF_SDK_FEATURES.md
+++ b/IWF_SDK_FEATURES.md
@@ -593,6 +593,16 @@ A third pass (full diff catalog, serialization included) then fixed the remainin
 - **Client API**: `publishToInternalChannelBatch`, a `waitForWorkflowCompletion` void alias, and
   permitting a workflow with no starting state (matches Java).
 
+### Resolved (AUTOPLAT-1934)
+Found while porting the Java integration suite (AUTOPLAT-1933), after the three audits below:
+- **Bug — `getAllWorkflowDataAttributes` omitted prefix-declared attributes.** It resolved the
+  registry's *exactly*-declared keys and sent them as a filter, so any runtime-named key written under
+  a `dataAttributePrefixDef` was silently missing from the result. It now sends no key filter, which
+  the server treats as "return everything" — matching Java's `getAllDataAttributes`, which passes
+  `null` keys for exactly this reason. (`getAllWorkflowSearchAttributes` is *not* affected: Java also
+  builds the full declared key-type list there, since the server needs the types to decode, so
+  sending all declared keys is the correct behavior.)
+
 ### Not applicable by design
 - **Data-attribute value-type validation** — data-attribute defs carry no declared type (TS uses the
   `ObjectEncoder`, not `Class<T>`), so there is no value type to validate. Key/prefix validation *is* enforced.
@@ -629,7 +639,10 @@ From the 2026-06-30 re-audits; intentionally left as-is:
 ### Third full audit (2026-06-30)
 A third complete TS↔Java diff (serialization included) confirmed the SDK is wire- and behavior-aligned:
 **~110 MATCH · ~160 intentional/idiomatic differences · ~25 minor non-intentional deltas — zero
-correctness gaps**, with every previously-fixed item verified MATCH. The remaining non-intentional
+correctness gaps**, with every previously-fixed item verified MATCH. That zero-gap conclusion did not
+hold: the `getAllWorkflowDataAttributes` prefix-key bug above (AUTOPLAT-1934) escaped all three audits
+and was only caught by porting the Java integration tests — so treat the audits as thorough on the
+wire contract but not exhaustive on registry-derived request arguments. The remaining non-intentional
 deltas are ergonomics/convenience only (e.g. no empty-keys guard on attribute reads, missing
 `getStateResultsSize()`/`getErrorDetails()`/`dockerDefault` conveniences, `Context.workflowType`
 optional vs required, `2^n` vs Feign's ~1.5× backoff curve) and are catalogued above as accepted.

--- a/iwf/src/client.ts
+++ b/iwf/src/client.ts
@@ -244,8 +244,10 @@ export class Client {
         workflowId: string,
         workflowRunId?: string,
     ): Promise<Map<string, unknown>> {
-        const keys = Array.from(this.registry.getDataAttributeKeys(workflow.getWorkflowType()));
-        return this.getWorkflowDataAttributes(workflow, workflowId, keys.length > 0 ? keys : undefined, workflowRunId);
+        // Send no keys so the server returns every data attribute. Sending the registry's
+        // exactly-declared keys would silently drop runtime-named attributes declared via a
+        // dataAttributePrefixDef (matches the Java SDK, whose getAllDataAttributes passes null keys).
+        return this.getWorkflowDataAttributes(workflow, workflowId, undefined, workflowRunId);
     }
 
     public async getWorkflowSearchAttributes(

--- a/iwf/test/unblocked-features.test.ts
+++ b/iwf/test/unblocked-features.test.ts
@@ -3,7 +3,7 @@ import { StateDecisionMapper } from "../src/mapper/state-decision-mapper";
 import { CommandResultsMapper } from "../src/mapper/command-results-mapper";
 import { Client } from "../src/client";
 import { defaultObjectEncoder } from "../src/object-encoder";
-import { PersistenceLoadingType, SearchAttributeValueType, WorkflowConditionalCloseType, WorkflowStartRequest, WorkflowStatus } from "../../gen/iwfidl";
+import { KeyValue, PersistenceLoadingType, SearchAttributeValueType, WorkflowConditionalCloseType, WorkflowStartRequest, WorkflowStatus } from "../../gen/iwfidl";
 import { UnregisteredClient } from "../src/unregistered-client";
 import { WorkflowUncompletedError } from "../src/errors";
 import { UnregisteredWorkflowOptionsBuilder } from "../src/unregistered-workflow-options";
@@ -54,6 +54,18 @@ class CachingRpcWorkflow implements ObjectWorkflow {
     }
     getPersistenceOptions(): PersistenceOptions {
         return new PersistenceOptions(true);
+    }
+}
+
+class PrefixedDataAttributeWorkflow implements ObjectWorkflow {
+    getWorkflowType(): string {
+        return "prefixedDataAttributes";
+    }
+    getWorkflowStates(): StateDef[] {
+        return [StateDef.startingState(rpcState)];
+    }
+    getPersistenceSchema(): PersistenceFieldDef[] {
+        return [PersistenceFieldDef.dataAttributeDef("user"), PersistenceFieldDef.dataAttributePrefixDef("dyn_")];
     }
 }
 
@@ -235,6 +247,37 @@ describe("useMemoForDataAttributes on start and reads (caching enabled)", () => 
         const { client, unregistered } = buildClient();
         await client.getWorkflowDataAttributes(new CachingRpcWorkflow(), "wf-1", ["k"]);
         expect(unregistered.getWorkflowDataAttributes.mock.calls[0][3]).toBe(true);
+    });
+});
+
+describe("getAllWorkflowDataAttributes with prefix-declared keys", () => {
+    const buildClient = (objects: KeyValue[]): { client: Client; unregistered: { getWorkflowDataAttributes: jest.Mock } } => {
+        const registry = new Registry();
+        registry.addWorkflow(new PrefixedDataAttributeWorkflow());
+        const client = new Client(registry, localDefaultClientOptions());
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const unregistered = (client as any).unregistered;
+        unregistered.getWorkflowDataAttributes = jest.fn(() => Promise.resolve(objects));
+        return { client, unregistered };
+    };
+
+    it("sends no key filter so the server returns every attribute", async () => {
+        const { client, unregistered } = buildClient([]);
+        await client.getAllWorkflowDataAttributes(new PrefixedDataAttributeWorkflow(), "wf-1");
+        // 2nd positional arg is the key filter; undefined tells the iwf server to return all of them.
+        // Sending the exactly-declared keys instead would exclude anything named under "dyn_".
+        expect(unregistered.getWorkflowDataAttributes.mock.calls[0][1]).toBeUndefined();
+    });
+
+    it("returns runtime-named attributes that were declared by prefix", async () => {
+        const { client } = buildClient([
+            { key: "user", value: defaultObjectEncoder.encode("alice") },
+            { key: "dyn_42", value: defaultObjectEncoder.encode({ n: 42 }) },
+        ]);
+        const attributes = await client.getAllWorkflowDataAttributes(new PrefixedDataAttributeWorkflow(), "wf-1");
+        expect(attributes.get("user")).toBe("alice");
+        expect(attributes.get("dyn_42")).toEqual({ n: 42 });
+        expect(attributes.size).toBe(2);
     });
 });
 


### PR DESCRIPTION
getAllWorkflowDataAttributes should send no keys so the server returns every data attribute